### PR TITLE
Fix: Correctly handle socials data in addTeamMember

### DIFF
--- a/server/src/app/modules/teamMember/teamMember.service.ts
+++ b/server/src/app/modules/teamMember/teamMember.service.ts
@@ -6,9 +6,6 @@ import { TeamMember } from '@prisma/client';
  const createTeamMemberService =  async (req: Request) => {
     const { name, role, bio, dataAiHint } = req.body;
     const avatar = req.file?.path || '';
-    const socialsString = req.body.socials || '[]';
-
-    const socials = JSON.parse(socialsString); // should be [{ platform: 'Facebook', url: '...' }]
 
     const newMember = await prisma.teamMember.create({
       data: {
@@ -18,7 +15,7 @@ import { TeamMember } from '@prisma/client';
         avatar,
         dataAiHint,
         socials: {
-          create: socials,
+          create: req.body.socials,
         },
       },
 


### PR DESCRIPTION
The previous implementation incorrectly tried to parse the 'socials' field from the request body twice. This change ensures that the 'socials' data, which is already parsed by Zod in the route handler, is used directly when creating a new team member.

This resolves an issue where adding a team member might fail due to mishandling of the 'socials' array.