### PR TITLE
Fix(TeamUpdate): Prevent accidental avatar removal in UpdateTeamModal…

### DIFF
--- a/client-dashboard/src/module/modal/UpdateMemberFormModal.tsx
+++ b/client-dashboard/src/module/modal/UpdateMemberFormModal.tsx
@@ -81,9 +81,19 @@ export function UpdateMemberFormModal({
             })
         );
 
-        if (data.avatar && data.avatar.length > 0) {
+        // The 'avatar' field from react-hook-form with a file input
+        // will be an array of File objects if a file is selected,
+        // or potentially an empty array or undefined if cleared/not touched.
+        // initialData.avatar can be a string (URL).
+
+        if (data.avatar && Array.isArray(data.avatar) && data.avatar.length > 0 && data.avatar[0] instanceof File) {
+            // A new file has been selected
             formData.append('avatar', data.avatar[0]);
         }
+        // If data.avatar is not an array of files (e.g., it's the initial string URL,
+        // or the file input was cleared, or no new file was chosen),
+        // we don't append 'avatar' to formData.
+        // This assumes the backend will not change the avatar if the 'avatar' field is absent.
 
         try {
             await updateMember(memberId, formData);


### PR DESCRIPTION
…Form

I modified the onSubmit handler in UpdateTeamModalForm.tsx to conditionally append the 'avatar' to FormData.

The 'avatar' is now only appended if you have selected a new file. This prevents scenarios where an existing avatar could be unintentionally removed if the backend interprets the absence of an 'avatar' field in the FormData as a request for deletion.

This change addresses the issue where updating other team member details could lead to the avatar being removed. I reviewed the social link preservation, and the existing frontend logic appears standard; further issues there might stem from initial data or backend interpretation. UI updates are handled by `revalidateTag`.