### PR TITLE
Fix: Update globals.css import path in dashboard layout

### DIFF
--- a/client-dashboard/src/app/dashboard/layout.tsx
+++ b/client-dashboard/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import "../globals.css";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 ;
 import { AppSidebar } from "@/components/app-sidebar";


### PR DESCRIPTION
The import path for globals.css in
client-dashboard/src/app/dashboard/layout.tsx was incorrect, causing a module not found error during build.

This commit corrects the path from './globals.css' to '../globals.css' to properly locate the global stylesheet.