### PR TITLE
Fix: Resolve server component rendering error and improve auth stability

### DIFF
--- a/client-dashboard/src/app/dashboard/layout.tsx
+++ b/client-dashboard/src/app/dashboard/layout.tsx
@@ -1,6 +1,5 @@
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
-import { Toaster } from "sonner";
 import "../globals.css";
 
 export default function RootLayout({
@@ -17,7 +16,6 @@ export default function RootLayout({
             <SidebarTrigger className="-ml-1" />
           </div>
         </header>
-        <Toaster richColors position="top-center" />
         <div className="p-4 pt-0 min-h-screen">{children}</div>
       </SidebarInset>
     </SidebarProvider>

--- a/client-dashboard/src/context/UserContext.tsx
+++ b/client-dashboard/src/context/UserContext.tsx
@@ -34,7 +34,7 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     handleUser();
-  }, [isLoading]);
+  }, []); // Empty dependency array
 
   return (
     <UserContext.Provider value={{ user, setUser, isLoading, setIsLoading }}>

--- a/client-dashboard/src/service/auth/index.ts
+++ b/client-dashboard/src/service/auth/index.ts
@@ -55,11 +55,17 @@ export const getCurrentUser = async () => {
     accessToken ? "Token exists" : "No token found"
   );
 
-  let decodedData = null;
-
   if (accessToken) {
-    decodedData = await jwtDecode(accessToken);
-    return decodedData;
+    try {
+      // Assuming jwtDecode might return a promise or be async based on previous 'await'
+      // If jwtDecode is synchronous, the 'await' can be removed.
+      // For safety and consistency with prior use, keeping await.
+      const decodedData = await jwtDecode(accessToken);
+      return decodedData;
+    } catch (error) {
+      console.error("Error decoding access token:", error);
+      return null;
+    }
   } else {
     return null;
   }


### PR DESCRIPTION
This commit addresses a server component rendering error by:

1. Modifying `UserContext.tsx` to prevent an infinite `useEffect` loop. The dependency array of the main `useEffect` was changed from `[isLoading]` to `[]` to ensure user data is fetched only once on mount.

2. Adding error handling to the `getCurrentUser` function in `service/auth/index.ts`. The `jwtDecode` call is now wrapped in a try-catch block to prevent unhandled errors from malformed tokens from crashing the rendering process. If decoding fails, an error is logged, and `null` is returned.

Additionally, a minor cleanup was performed:
- Removed a duplicate `<Toaster />` component from `dashboard/layout.tsx` as it was already present in the root layout.

These changes aim to stabilize the application during server-side rendering, particularly related to user authentication and context initialization.