### PR TITLE
Fix: Resolve JwtPayload type error

### DIFF
--- a/client-dashboard/src/service/auth/index.ts
+++ b/client-dashboard/src/service/auth/index.ts
@@ -4,6 +4,7 @@
 import { FieldValues } from "react-hook-form";
 import { cookies } from "next/headers";
 import { jwtDecode } from "jwt-decode";
+import { DecodedUser } from "../../type";
 
 export const registerUser = async (userData: FieldValues) => {
   try {
@@ -60,7 +61,7 @@ export const getCurrentUser = async () => {
       // Assuming jwtDecode might return a promise or be async based on previous 'await'
       // If jwtDecode is synchronous, the 'await' can be removed.
       // For safety and consistency with prior use, keeping await.
-      const decodedData = await jwtDecode(accessToken);
+      const decodedData = await jwtDecode<DecodedUser>(accessToken);
       return decodedData;
     } catch (error) {
       console.error("Error decoding access token:", error);

--- a/client-dashboard/src/type/index.ts
+++ b/client-dashboard/src/type/index.ts
@@ -1,3 +1,5 @@
+import { JwtPayload } from "jwt-decode";
+
 export type TUser = {
   id: string;
   name: string;
@@ -7,3 +9,5 @@ export type TUser = {
   updatedAt: string;
 
 };
+
+export type DecodedUser = JwtPayload & TUser;

--- a/server/src/app/modules/auth/auth.service.ts
+++ b/server/src/app/modules/auth/auth.service.ts
@@ -43,9 +43,11 @@ const logInUser = async (
   // ✅ Token Generate
   const accessToken = jwtHelpers.createToken(
     {
-      userId: userData.id,
+      id: userData.id,
       email: userData.email,
       name: userData.name,
+      createdAt: userData.createdAt,
+      updatedAt: userData.updatedAt,
     },
     config.jwt.secret as string,
     config.jwt.expiresIn as string
@@ -53,9 +55,11 @@ const logInUser = async (
 
   const newRefreshToken = jwtHelpers.createToken(
     {
-      userId: userData.id,
+      id: userData.id,
       email: userData.email,
       name: userData.name,
+      createdAt: userData.createdAt,
+      updatedAt: userData.updatedAt,
     },
     config.jwt.refresh_token_secret as string,
     config.jwt.refresh_token_expires_in as string
@@ -83,9 +87,11 @@ const refreshToken = async (token: string) => {
 
   const accessToken = jwtHelpers.createToken(
     {
-      userId: userData.id,
+      id: userData.id,
       email: userData.email,
       name: userData.name,
+      createdAt: userData.createdAt,
+      updatedAt: userData.updatedAt,
     },
     config.jwt.secret as string,
     config.jwt.expiresIn as string


### PR DESCRIPTION
The `currentUser` variable was encountering a type error because `JwtPayload` from `jwt-decode` did not match the expected `TUser` type.

This commit addresses the issue by:

1. Modifying the server-side JWT creation (`server/src/app/modules/auth/auth.service.ts`) to include all fields expected by `TUser` (`id`, `name`, `email`, `createdAt`, `updatedAt`) in the JWT payload.
2. Defining a new type `DecodedUser` on the client-side (`client-dashboard/src/type/index.ts`) which extends `JwtPayload` and incorporates the properties of `TUser`.
3. Updating the `getCurrentUser` function (`client-dashboard/src/service/auth/index.ts`) to use this `DecodedUser` type when decoding the JWT, ensuring type compatibility.

These changes ensure that the decoded JWT payload aligns with the `TUser` type, resolving the TypeScript error.